### PR TITLE
Fix unclickable top area

### DIFF
--- a/src/css/style_mosaico_content.less
+++ b/src/css/style_mosaico_content.less
@@ -226,6 +226,7 @@
   top: -16px;
   left: 0;
   right: 0;
+  height: 1px;
   z-index: 20;
   text-align: center;
   /* width: 100%;*/


### PR DESCRIPTION
In some cases top area elements not clickable (and wysiwyg not started)

I changed height to be fixed 1px. There is no "overflow: hidden" so icons will work as well.