### PR TITLE
Docker support is ready.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM    centos:centos6
+
+# Enable Extra Packages for Enterprise Linux (EPEL) for CentOS
+RUN     yum install -y epel-release
+# Install Node.js and npm
+RUN     yum install -y git nodejs npm imagemagick bzip2 tar
+
+# Install app dependencies
+COPY package.json /src/package.json
+RUN npm install grunt-cli -g
+
+RUN cd /src; npm install; 
+
+
+# Bundle app source
+COPY . /src
+
+
+WORKDIR /src
+
+EXPOSE  9006
+CMD ["grunt"]

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -144,7 +144,7 @@ module.exports = function(grunt) {
         options: {
           port: 9006,
           showStack: true,
-          hostname: '127.0.0.1',
+          hostname: '0.0.0.0',
           open: true,
           bases: ['.'],
           server: 'backend/main.js'

--- a/makefile
+++ b/makefile
@@ -1,0 +1,10 @@
+all: build run
+
+build:
+	docker build -t piotr-mroczek/mosaico .
+
+run:
+	docker run -p 9006:9006 piotr-mroczek/mosaico	
+
+
+


### PR DESCRIPTION
Run "make" command on terminal to build Docker image and run it as Docker container. After few seconds You will be able to see Mosaic instance works on http://localhost:9006. 
