### PR TITLE
Import / Export newsletter edits

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -185,6 +185,8 @@ module.exports = function(grunt) {
           'tinymce.min.js': 'tinymce/tinymce.min.js',
           'jszip.min.js': 'jszip/dist/jszip.min.js',
           'FileSaver.js': 'jszip/vendor/FileSaver.js',
+          'toastr.min.js': 'toastr/toastr.min.js',
+          'toastr.min.css': 'toastr/toastr.min.css',
           'themes': 'tinymce/themes',
           'skins': 'tinymce/skins',
           'plugins': 'tinymce/plugins',

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -183,6 +183,8 @@ module.exports = function(grunt) {
           'jquery.fileupload-image.js': 'jquery-file-upload/js/jquery.fileupload-image.js',
           'jquery.fileupload-validate.js': 'jquery-file-upload/js/jquery.fileupload-validate.js',
           'tinymce.min.js': 'tinymce/tinymce.min.js',
+          'jszip.min.js': 'jszip/dist/jszip.min.js',
+          'FileSaver.js': 'jszip/vendor/FileSaver.js',
           'themes': 'tinymce/themes',
           'skins': 'tinymce/skins',
           'plugins': 'tinymce/plugins',

--- a/bower.json
+++ b/bower.json
@@ -33,7 +33,8 @@
     "juice": "bago/juice#abstract-dom",
     "slick": "shashankmehta/slick.js#ce20afabd1898e002c4a5a9b0c21281a2592889d",
     "tinycolor": "~1.2.1",
-    "webfont-notosans": "~0.1.0"
+    "webfont-notosans": "~0.1.0",
+    "jszip": "Stuk/jszip#^3.0.0"
   },
   "overrides": {
     "console-browserify": {

--- a/index.html
+++ b/index.html
@@ -25,32 +25,12 @@
 
     <script src="dist/vendor/knockout.js"></script>
     <script src="dist/vendor/jquery.min.js"></script>
+    <script src="dist/vendor/jszip.min.js"></script>
+    <script src="dist/vendor/FileSaver.js"></script>
     <script>
-      var initialEdits = [];
-      if (localStorage.getItem('edits')) {
-        var editKeys = JSON.parse(localStorage.getItem('edits'));
-        var md;
-        for (var i = 0; i < editKeys.length; i++) {
-          md = localStorage.getItem('metadata-'+editKeys[i]);
-          if (typeof md == 'string') {
-            initialEdits.push(JSON.parse(md));
-          } else {
-            console.log("Ignoring saved key", editKeys[i], "type", typeof md, md);
-          }
-        }
-
-        initialEdits.sort(function(a, b) {
-          var lastA = a.changed ? a.changed : a.created;
-          var lastB = b.changed ? b.changed : b.created;
-          if (lastA < lastB) return 1;
-          if (lastA > lastB) return -1;
-          return 0;
-        });
-      }
-
       var viewModel = {
         showSaved: ko.observable(false),
-        edits: ko.observableArray(initialEdits),
+        edits: ko.observableArray(readEdits()),
         templates: [{
           name: 'versafix-1', desc: 'The versatile template'
         },{
@@ -116,6 +96,176 @@
           } else {
             console.log("ls ", key, localStorage.getItem(key));
           }
+        }
+      };
+
+      /**
+       * Extract Zip, read content and call 'importEdit'
+       *
+       * @param {File} f
+       */
+      function handleFile(f) {
+        var editId = getEditIdFromFilename(f.name);
+        if (editId !== false) {
+
+          var deferred = {
+            metadata: $.Deferred(),
+            template: $.Deferred()
+          };
+
+          $.when(deferred.metadata, deferred.template).then(function(file1, file2) {
+            if (arguments.length !== 2) {
+              alert('Invalid file');
+              return;
+            }
+            if (importEdit(editId, file1, file2)) {
+              var editsData = readEdits();
+              viewModel.edits.removeAll();
+              viewModel.edits.push.apply(viewModel.edits, editsData);
+            }
+          });
+
+          JSZip.loadAsync(f)
+                  .then(function(zip) {
+                    zip.forEach(function(relativePath, zipEntry) {
+                      var def;
+
+                      if (zipEntry.name.indexOf('metadata') === 0){
+                        def = deferred.metadata;
+                      } else if (zipEntry.name.indexOf('template') === 0) {
+                        def = deferred.template;
+                      } else {
+                        console.error('Invalid Zip content')
+                      }
+
+                      zipEntry.async("string").then(function success(content) {
+                        def.resolve(content);
+                      }, function error(e) {
+                        def.reject(e);
+                      });
+                    });
+                  }, function(e) {
+                    console.error(f.name, e.message);
+                  });
+
+          return;
+        }
+
+        alert('Invalid file');
+      }
+
+      /**
+       * Check filename is like mosaico_{id}.zip
+       * Return {id}
+       *
+       * @param {string} filename
+       * @returns {string|false}
+       */
+      function getEditIdFromFilename(filename) {
+        var temp = filename.split('.');
+        if (temp.length===2) {
+          var parts = temp[0].split('_');
+          if (parts[0] === 'mosaico') {
+            return parts[1];
+          }
+        }
+        return false;
+      }
+
+      /**
+       * Transform edits localstorage into Ko ready array
+       *
+       * @returns {Array}
+       */
+      function readEdits() {
+
+        var edits = [];
+        if (localStorage.getItem('edits')) {
+          var editKeys = JSON.parse(localStorage.getItem('edits'));
+          var md;
+
+          for (var i = 0; i < editKeys.length; i++) {
+            md = localStorage.getItem('metadata-' + editKeys[i]);
+            if (typeof md == 'string') {
+              edits.push(JSON.parse(md));
+            } else {
+              console.log("Ignoring saved key", editKeys[i], "type", typeof md, md);
+            }
+          }
+
+          edits.sort(function (a, b) {
+            var lastA = a.changed ? a.changed : a.created;
+            var lastB = b.changed ? b.changed : b.created;
+            if (lastA < lastB) return 1;
+            if (lastA > lastB) return -1;
+            return 0;
+          });
+        }
+        return edits;
+      }
+
+      /**
+       *
+       * @param id
+       * @param metadata
+       * @param template
+       */
+      function importEdit(id, metadata, template) {
+        var editKeys = JSON.parse(localStorage.getItem('edits'));
+
+        if (editKeys.indexOf(id) === -1) {
+          editKeys.push(id);
+          localStorage.setItem('edits', JSON.stringify(editKeys));
+          localStorage.setItem("metadata-" + id, metadata);
+          localStorage.setItem("template-" + id, template);
+          return true;
+        }
+
+        alert("Oops, config " + id + " already loaded");
+        return false;
+      }
+
+      /**
+       * Get data from localstorage and output a zip to the browser
+       *
+       * @param {String} index Edit id
+       */
+      viewModel.exportEdit = function(index) {
+
+        var editId              = viewModel.edits()[index].key,
+                metadataFilename    = 'metadata-'+editId,
+                templateFilename    = 'template-'+editId,
+                metadataContent     = localStorage.getItem(metadataFilename),
+                templateContent     = localStorage.getItem(templateFilename);
+
+        if (metadataContent === null || templateContent === null) {
+          alert('Ooops, can\'t find NL ' + editId);
+          return false;
+        }
+
+        var zip = new JSZip();
+        zip.file(metadataFilename + '.json', metadataContent);
+        zip.file(templateFilename + '.json', templateContent);
+        zip.generateAsync({type:"blob"})
+                .then(function (blob) {
+                  saveAs(blob, "mosaico_"+editId+".zip");
+                }, function (err) {
+                  throw err;
+                });
+
+        return false;
+      };
+
+      /**
+       * Event handler to the input file change event
+       *
+       * @param {Object} data
+       * @param {Event} event Change event
+       */
+      viewModel.fileSelected = function(data, event) {
+        var files = event.target.files;
+        for (var i = 0, f; f = files[i]; i++) {
+          handleFile(f);
         }
       };
 
@@ -322,9 +472,16 @@ $(function() {
         <a class="operationButton" href="#" data-bind="attr: { href: 'editor.html#'+key }" title="edit"><i class="fa fa-pencil"></i></a>
         <!--(<a href="#" data-bind="click: $root.renameEdit.bind(undefined, $index())" title="rinomina"><i class="fa fa-trash-o"></i></a>)-->
         <a class="operationButton" href="#" data-bind="click: $root.deleteEdit.bind(undefined, $index())" title="delete"><i class="fa fa-trash-o"></i></a>
+        <a class="operationButton" href="#" data-bind="if: (window.FileReader && window.ArrayBuffer), click: $root.exportEdit.bind(undefined, $index())" title="Export"><i class="fa fa-save"></i></a>
         </td>
       </tr>
     </tbody>
+    <tfoot data-bind="if: (window.FileReader && window.ArrayBuffer)">
+    <tr>
+      <th colspan="4">Import</th>
+      <th><input type="file" name="import_config" accept="application/zip, .zip" data-bind="event:{ 'change': $root.fileSelected}" /></th>
+    </tr>
+    </tfoot>
     </table>
     <!-- /ko -->
     </div>

--- a/index.html
+++ b/index.html
@@ -22,12 +22,31 @@
 
     <link rel="stylesheet" href="dist/mosaico-material.min.css" />
     <link rel="stylesheet" href="dist/vendor/notoregular/stylesheet.css" />
+    <link rel="stylesheet" href="dist/vendor/toastr.min.css" />
 
     <script src="dist/vendor/knockout.js"></script>
     <script src="dist/vendor/jquery.min.js"></script>
     <script src="dist/vendor/jszip.min.js"></script>
     <script src="dist/vendor/FileSaver.js"></script>
+    <script src="dist/vendor/toastr.min.js"></script>
     <script>
+      //FIXME copy paste from viewmodel.js
+      toastr.options = {
+        "closeButton": false,
+        "debug": false,
+        "positionClass": "toast-bottom-full-width",
+        "target": "#mo-body",
+        "onclick": null,
+        "showDuration": "300",
+        "hideDuration": "1000",
+        "timeOut": "5000",
+        "extendedTimeOut": "1000",
+        "showEasing": "swing",
+        "hideEasing": "linear",
+        "showMethod": "fadeIn",
+        "hideMethod": "fadeOut"
+      };
+
       var viewModel = {
         showSaved: ko.observable(false),
         edits: ko.observableArray(readEdits()),
@@ -39,6 +58,22 @@
           name: 'tutorial', desc: 'The Tutorial'
         }]
       };
+
+      //FIXME copy paste from viewmodel.js
+      viewModel.notifier = toastr;
+
+      //FIXME copy paste from viewmodel.js
+      viewModel.tt = function(key, paramObj) {
+        if (typeof paramObj !== 'undefined')
+          for (var prop in paramObj)
+            if (paramObj.hasOwnProperty(prop)) {
+              key = key.replace(new RegExp('__' + prop + '__', 'g'), paramObj[prop]);
+            }
+        return key;
+      };
+
+      //FIXME copy paste from viewmodel.js
+      viewModel.t = viewModel.tt;
 
       viewModel.edits.subscribe(function(newEdits) {
         var keys = [];
@@ -69,6 +104,7 @@
         // { data: 'AAAA-MM-GG', key: 'ABCDE' }
         // viewModel.edits.push(template);
       };
+
       viewModel.renameEdit = function(index) {
         var newName = window.prompt("Modifica nome", viewModel.edits()[index].name);
         if (newName) {
@@ -78,6 +114,7 @@
         }
         return false;
       };
+
       viewModel.deleteEdit = function(index) {
         var confirm = window.confirm("Are you sure you want to delete this content?");
         if (confirm) {
@@ -87,6 +124,7 @@
         }
         return false;
       };
+
       viewModel.list = function(clean) {
         for (var i = localStorage.length - 1; i >= 0; i--) {
           var key = localStorage.key(i);
@@ -98,6 +136,49 @@
           }
         }
       };
+      /**
+       * Event handler to the input file change event
+       *
+       * @param {Object} data
+       * @param {Event} event Change event
+       */
+      viewModel.fileSelected = function(data, event) {
+        var files = event.target.files;
+        for (var i = 0, f; f = files[i]; i++) {
+          handleFile(f);
+        }
+      };
+
+      /**
+       * Get data from localstorage and output a zip to the browser
+       *
+       * @param {String} index Edit id
+       */
+      viewModel.exportEdit = function(index) {
+
+        var editId = viewModel.edits()[index].key,
+          metadataFilename    = 'metadata-'+editId,
+          templateFilename    = 'template-'+editId,
+          metadataContent     = localStorage.getItem(metadataFilename),
+          templateContent     = localStorage.getItem(templateFilename);
+
+        if (metadataContent === null || templateContent === null) {
+          viewModel.notifier.error(viewModel.t('Ooops, can\'t find NL __id__', {id: editId}));
+          return false;
+        }
+
+        var zip = new JSZip();
+        zip.file(metadataFilename + '.json', metadataContent);
+        zip.file(templateFilename + '.json', templateContent);
+        zip.generateAsync({type:"blob"})
+                .then(function (blob) {
+                  saveAs(blob, "mosaico_"+editId+".zip");
+                }, function (err) {
+                  viewModel.notifier.error(viewModel.t('Error while creating the export : __e__', {e: err}));
+                });
+
+        return false;
+      };
 
       /**
        * Extract Zip, read content and call 'importEdit'
@@ -105,53 +186,55 @@
        * @param {File} f
        */
       function handleFile(f) {
-        var editId = getEditIdFromFilename(f.name);
-        if (editId !== false) {
 
+        var editId = getEditIdFromFilename(f.name);
+
+        if (editId !== false) {
           var deferred = {
             metadata: $.Deferred(),
             template: $.Deferred()
           };
 
-          $.when(deferred.metadata, deferred.template).then(function(file1, file2) {
-            if (arguments.length !== 2) {
-              alert('Invalid file');
-              return;
-            }
-            if (importEdit(editId, file1, file2)) {
-              var editsData = readEdits();
-              viewModel.edits.removeAll();
-              viewModel.edits.push.apply(viewModel.edits, editsData);
-            }
-          });
+          $.when(deferred.metadata, deferred.template)
+            .then(function(file1, file2) {
+              if (arguments.length !== 2) {
+                viewModel.notifier.error(viewModel.t('Invalid zip content'));
+                return;
+              }
+              if (importEdit(editId, file1, file2)) {
+                var editsData = readEdits();
+                viewModel.edits.removeAll();
+                viewModel.edits.push.apply(viewModel.edits, editsData);
+              }
+            });
 
           JSZip.loadAsync(f)
-                  .then(function(zip) {
-                    zip.forEach(function(relativePath, zipEntry) {
-                      var def;
+            .then(function(zip) {
+              zip.forEach(function(relativePath, zipEntry) {
+                var def;
 
-                      if (zipEntry.name.indexOf('metadata') === 0){
-                        def = deferred.metadata;
-                      } else if (zipEntry.name.indexOf('template') === 0) {
-                        def = deferred.template;
-                      } else {
-                        console.error('Invalid Zip content')
-                      }
+                if (zipEntry.name.indexOf('metadata') === 0){
+                  def = deferred.metadata;
+                } else if (zipEntry.name.indexOf('template') === 0) {
+                  def = deferred.template;
+                } else {
+                  viewModel.notifier.error(viewModel.t('Invalid Zip content'));
+                }
 
-                      zipEntry.async("string").then(function success(content) {
-                        def.resolve(content);
-                      }, function error(e) {
-                        def.reject(e);
-                      });
-                    });
-                  }, function(e) {
-                    console.error(f.name, e.message);
-                  });
+                zipEntry.async("string").then(function success(content) {
+                  def.resolve(content);
+                }, function error(e) {
+                  def.reject(e);
+                });
+              });
+            }, function(e) {
+              viewModel.notifier.error(viewModel.t('Zip read fail : __e__', {e: e.message}));
+            });
 
           return;
         }
 
-        alert('Invalid file');
+        viewModel.notifier.error(viewModel.t('Invalid zip name'));
       }
 
       /**
@@ -221,53 +304,9 @@
           return true;
         }
 
-        alert("Oops, config " + id + " already loaded");
+        viewModel.notifier.error(viewModel.t("Oops, config __id__ already loaded", {id:id}));
         return false;
       }
-
-      /**
-       * Get data from localstorage and output a zip to the browser
-       *
-       * @param {String} index Edit id
-       */
-      viewModel.exportEdit = function(index) {
-
-        var editId              = viewModel.edits()[index].key,
-                metadataFilename    = 'metadata-'+editId,
-                templateFilename    = 'template-'+editId,
-                metadataContent     = localStorage.getItem(metadataFilename),
-                templateContent     = localStorage.getItem(templateFilename);
-
-        if (metadataContent === null || templateContent === null) {
-          alert('Ooops, can\'t find NL ' + editId);
-          return false;
-        }
-
-        var zip = new JSZip();
-        zip.file(metadataFilename + '.json', metadataContent);
-        zip.file(templateFilename + '.json', templateContent);
-        zip.generateAsync({type:"blob"})
-                .then(function (blob) {
-                  saveAs(blob, "mosaico_"+editId+".zip");
-                }, function (err) {
-                  throw err;
-                });
-
-        return false;
-      };
-
-      /**
-       * Event handler to the input file change event
-       *
-       * @param {Object} data
-       * @param {Event} event Change event
-       */
-      viewModel.fileSelected = function(data, event) {
-        var files = event.target.files;
-        for (var i = 0, f; f = files[i]; i++) {
-          handleFile(f);
-        }
-      };
 
       document.addEventListener('DOMContentLoaded',function(){
         ko.applyBindings(viewModel);
@@ -448,6 +487,7 @@ $(function() {
 
   </head>
   <body style="overflow: auto; text-align: center; background-color: #3f3d33; padding: 0; margin: 0; display: none;" data-bind="visible: true">
+  <div class="mo" id="mo-body"></div>
   <div style="background-color: #d2cbb1; padding: 10px;">
     <table class="logoWrapper" valign="bottom" align="center"><tr><td valign="bottom"><img class="logoImage" alt="Mosaico.io" style="display: block;" src="dist/img/mosaicologo.png" /><div class="logoContainer"></div></td><td class="byTable" valign="bottom"><a href="http://www.voxmail.it"><img src="dist/img/byvoxmail.png" alt="by VOXmail" /></a></td></tr></table>
     <div class="ribbon">opensource email template editor <span class="byRibbon" style="display: none;">by VOXmail</span></div>


### PR DESCRIPTION
Hello,

Use [JSZip](https://stuk.github.io/jszip/) in Mosaico homepage so that a user can export / import from local storage.

_metadata-{edit-id}.json_ and _template-{edit-id}.json_ are bundled together in a simple **mosaico_{edit-id}.zip**

The ZIP is read with [FileReader](https://github.com/eligrey/FileSaver.js) and save in local-storage

No server required. Only [File](https://developer.mozilla.org/fr/docs/Web/API/File) and [ArrayBuffer](https://developer.mozilla.org/fr/docs/Web/JavaScript/Reference/Objets_globaux/ArrayBuffer)

⚠️ Some code is duplicated from **viewmodel.js**, from _editor.html_. Wants to start small, and touch the least possible file.  am completely open to discussion.

![import-export-screenshot](https://cloud.githubusercontent.com/assets/6448828/17248448/e0cfde7a-559a-11e6-8884-52bc7a829190.png)
