### PR TITLE
imgProcessorBackend - Improve compatibility with `?` or `&`

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -42,7 +42,8 @@ var applyBindingOptions = function(options, ko) {
   };
 
   ko.bindingHandlers.wysiwygSrc.placeholderUrl = function(width, height, text) {
-    return options.imgProcessorBackend + "?method=" + 'placeholder' + "&params=" + width + encodeURIComponent(",") + height;
+    var queryParamSeparator = options.imgProcessorBackend.indexOf('?') == -1 ? '?' : '&';
+    return options.imgProcessorBackend + queryParamSeparator + "method=" + 'placeholder' + "&params=" + width + encodeURIComponent(",") + height;
   };
 
   // pushes custom tinymce configurations from options to the binding


### PR DESCRIPTION
If loading Mosaico inside an existing PHP application (such as WordPress or
Joomla), the backend URL may already include a variety of parameters.  But
this is not universal -- some applications can consistently support clean
URLs.

This patch handles the backend URL adaptively, so it should work with URLs like either:

 * `https://example.com/imageBackend`
 * `https://example.com/index.php?module=Mosaico&controller=imageBackend`

Port from https://github.com/veda-consulting/uk.co.vedaconsulting.mosaico/commit/0d0cf8658fd323fe46978130b0bd8f7259834add
Port from https://github.com/veda-consulting/uk.co.vedaconsulting.mosaico/commit/8295456cb42b614b186993355f112937ec610d16