### PR TITLE
bower.json + if-subs.js - Fix random breaks from misaligned version constraints

### DIFF
--- a/src/js/bindings/if-subs.js
+++ b/src/js/bindings/if-subs.js
@@ -69,16 +69,13 @@ var afterSubscriptionProp;
 if (typeof ko.subscription == 'function' && typeof ko.isWritableObservable !== 'undefined') {
   beforeSubscriptionProp = 'beforeSubscriptionAdd';
   afterSubscriptionProp = 'afterSubscriptionRemove';
-} else if (ko.version == "3.2.0") {
+} else if (ko.version.match(/^3\.2\./)) {
   beforeSubscriptionProp = 'va';
   afterSubscriptionProp = 'nb';
-} else if (ko.version == "3.3.0") {
+} else if (ko.version.match(/^3\.3\./)) {
   beforeSubscriptionProp = 'ja';
   afterSubscriptionProp = 'ua';
-} else if (ko.version == "3.4.0") {
-  beforeSubscriptionProp = 'sa';
-  afterSubscriptionProp = 'Ia';
-} else if (ko.version == "3.4.1") {
+} else if (ko.version.match(/^3\.4\./)) {
   beforeSubscriptionProp = 'sa';
   afterSubscriptionProp = 'Ia';
 }


### PR DESCRIPTION
The file `bower.json` has a version constraint for KnockoutJS (`~3.4.0`
which basically means "any stable revision of 3.4.x").  The file
`if-subs.js` has a stricter version constraint (`3.3.0` or `3.4.0` or
`3.4.1`).  In the event that Knockout upstream provides a new point release
(e.g.  `3.4.2`), this misalignment immediately and unnecessarily breaks the
build.

The revision aligns the version constraints -- if we expect `3.4.2` to be
good enough for bower, then it should be good enough for `if-subs.js`.

(Note: They could also be aligned by editing `bower.json` to peg it to a
specific point-release.  That could make sense if you don't trust KnockoutJS
upstream's judgment on point-releases...  but this patch feels a bit more
maintainable...)