### PR TITLE
Improved Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,13 @@
-FROM centos:centos7
+FROM node:7
 
-RUN yum clean all
-RUN yum -y install epel-release; yum clean all
-RUN yum -y install bzip2 tar git nodejs npm ImageMagick; yum clean all
+RUN apt-get install -y ImageMagick
 
-RUN npm install grunt-cli -g
-
-ADD package.json /tmp/package.json
-RUN cd /tmp && npm install
-RUN mkdir -p /opt/mosaico && cp -a /tmp/node_modules /opt/mosaico/
-
-WORKDIR /opt/mosaico
 ADD . /opt/mosaico
+WORKDIR /opt/mosaico
+
+RUN  npm install grunt-cli -g \
+ && npm install \
+ && npm cache clear
 
 EXPOSE 9006
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
 FROM node:7
 
-RUN apt-get install -y ImageMagick
-
 ADD . /opt/mosaico
 WORKDIR /opt/mosaico
 


### PR DESCRIPTION
I Tought you could maybe be interrested in this.

It makes building and deployment as usage more simple

- will use the nativ node:7 image to easy upgrade node base versions and faster build
```
git clone https://github.com/voidlabs/mosaico

## Build Your Self
docker build -t mosaico/mosaico .

## RUN
docker run -it mosaico/mosaico


## Develop

### RUN Install
docker run --rm -v $PWD:/opt/mosaico mosaico/mosaico npm install

### RUN
docker run -it -v $PWD:/opt/mosaico mosaico/mosaico

```