### PR TITLE
Use node:6-alpine as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,13 @@
-FROM centos:centos7
+FROM node:6-alpine
 
-RUN yum clean all
-RUN yum -y install epel-release; yum clean all
-RUN yum -y install bzip2 tar git nodejs npm ImageMagick; yum clean all
-
-RUN npm install grunt-cli -g
+RUN apk update && apk add bzip2 tar imagemagick git && npm install grunt-cli -g
 
 # only add package.json so npm install will only be needed if we change it.
 COPY package.json /tmp/package.json
 # also add bower because package.json post-install needs it.
 COPY bower.json /tmp/bower.json
 RUN cd /tmp && npm install --unsafe-perm
-RUN mkdir -p /opt/mosaico && cp -a /tmp/node_modules /tmp/bower_components /opt/mosaico/
+RUN mkdir -p /opt/mosaico && cp -a /tmp/node_modules /tmp/bower_components /opt/mosaico/ && rm -rf /tmp/node_modules /tmp/bower_components
 
 WORKDIR /opt/mosaico
 COPY . /opt/mosaico


### PR DESCRIPTION
This PR change the base image for docker to make it lighter. Save 285MB approx.