### PR TITLE
Show color picker link buttons

### DIFF
--- a/src/css/app_standalone_material.less
+++ b/src/css/app_standalone_material.less
@@ -252,13 +252,6 @@
   box-shadow: none;
 }
 
-.mo {
-  a {
-    &:link, &:visited {
-      color: white;
-    }
-  }
-}
 #main-toolbox {
   .noSelectedBlock, .customStyleHelp, .objEmpty, .galleryEmpty {
     font-size: 1em;


### PR DESCRIPTION
This CSS selector causes my color picker links to effectively disappear:

![image](https://user-images.githubusercontent.com/575280/29689370-d4c6343c-88d7-11e7-9ed1-356d4f4bdb71.png)
