### PR TITLE
Upgrade bower to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "async": "2.0.1",
     "autoprefixer": "6.5.0",
     "body-parser": "1.15.2",
-    "bower": "1.7.9",
+    "bower": "1.8.2",
     "browserify": "14.4.0",
     "browserify-incremental": "3.1.1",
     "browserify-shim": "3.8.14",


### PR DESCRIPTION
Bower URL changed and some bower dependencies can no longer be downloaded from bower 1.7.x.