### PR TITLE
Fix undefined property when adding a property with a different default value.

### DIFF
--- a/src/js/converter/model.js
+++ b/src/js/converter/model.js
@@ -454,7 +454,7 @@ var modelEnsurePathAndGetBindValue = function(readonly, defs, themeUpdater, root
         // This remove default value. Ugly. (Needs this for defaults in template-lm socialLinksIcon)
         defs[modelName]._defaultValues[path] = null;
       } else if (defs[modelName]._defaultValues[path] != defaultValue) {
-        throw "Trying to set a new default value for " + modelName + " " + path + " while it already exists (current: " + defs[modelName].defaultValues[path] + ", new: " + defaultValue + ")";
+        throw "Trying to set a new default value for " + modelName + " " + path + " while it already exists (current: " + defs[modelName]._defaultValues[path] + ", new: " + defaultValue + ")";
       }
     }
   }


### PR DESCRIPTION
short story: a property accessor is missing an _ raising another exception and making debugging difficult.

When developing a template, I found myself stuck with a strange error about an unidentified property.

After some investigation, I found that I was adding a property with a different defaultValue than a previous one declared, but the exception was not helpful.

This fix simply add the missing character.