### PR TITLE
Add experimental Url.templatePath and Url.imageProcessor methods for the templating language

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -12,6 +12,7 @@ var performanceAwareCaller = require("./timed-call.js").timedCall;
 var addUndoStackExtensionMaker = require("./undomanager/undomain.js");
 var colorPlugin = require("./ext/color.js");
 var utilPlugin = require("./ext/util.js");
+var urlPlugin = require("./ext/url.js");
 var inlinerPlugin = require("./ext/inliner.js");
 
 var localStorageLoader = require("./ext/localstorage.js");
@@ -118,7 +119,7 @@ var start = function(options, templateFile, templateMetadata, jsorjson, customEx
   };
 
   // simpleTranslationPlugin must be before the undoStack to translate undo/redo labels
-  var extensions = [simpleTranslationPlugin, addUndoStackExtensionMaker(performanceAwareCaller), colorPlugin, utilPlugin, inlinerPlugin];
+  var extensions = [simpleTranslationPlugin, addUndoStackExtensionMaker(performanceAwareCaller), colorPlugin, utilPlugin, urlPlugin, inlinerPlugin];
   if (typeof customExtensions !== 'undefined')
     for (var k = 0; k < customExtensions.length; k++) extensions.push(customExtensions[k]);
   extensions.push(fileUploadMessagesExtension);

--- a/src/js/converter/utils.js
+++ b/src/js/converter/utils.js
@@ -77,7 +77,7 @@ var conditionBinding = function(expression, bindingProvider, defVal) {
       // return gen(node.object) + '[' + gen(node.property) + ']';
     } else if (node.type == 'MemberExpression' && !node.computed) {
       var me = gen(node.object, bindingProvider, false) + '.' + gen(node.property, bindingProvider, false);
-      if (lookupmember && node.object.name !== 'Math' && node.object.name !== 'Color' && node.object.name !== 'Util') return bindingProvider(me, defVal) + '()';
+      if (lookupmember && node.object.name !== 'Math' && node.object.name !== 'Color' && node.object.name !== 'Util' && node.object.name !== 'Url') return bindingProvider(me, defVal) + '()';
       return me;
     } else if (node.type === "Literal") {
       return node.raw;

--- a/src/js/ext/url.js
+++ b/src/js/ext/url.js
@@ -1,0 +1,18 @@
+"use strict";
+/* global global: false */
+var ko = require("knockout");
+
+// WARNING: these are experimental and we may remove them in future releases,
+//          if you use them please get in touch with developers
+var urlPlugin = function(vm) {
+  global.Url = {
+    'templatePath': function() {
+      return vm.templatePath.apply(vm, arguments);
+    },
+    'imageProcessor': function() {
+      return ko.bindingHandlers.wysiwygSrc.convertedUrl.apply(ko.bindingHandlers.wysiwygSrc, arguments);
+    },
+  };
+};
+
+module.exports = urlPlugin;

--- a/src/js/ext/util.js
+++ b/src/js/ext/util.js
@@ -1,3 +1,6 @@
+"use strict";
+/* global global: false */
+
 var utilPlugin = function(vm) {
   global.Util = {
     'decodeURI': decodeURI,


### PR DESCRIPTION
Url.templatePath will let us to have a smaller template with regard to the versafix-1 big social block as the iconset will become a simple variable to build the image urls instead of a full block variant.

Url.imageProcessor may help creating special block with special backend processing features in custom deployments.