### PR TITLE
fix(backend): Possibility to use `SERVER_URL` to overwrite upload url (e.g. proxy http -> https)

### DIFF
--- a/backend/main.js
+++ b/backend/main.js
@@ -38,7 +38,7 @@ var uploadOptions = {
 
 app.get('/upload/', function(req, res) {
     var files = [];
-    var uploadHost = req.protocol + '://' + req.get('host');
+    var uploadHost = process.env.SERVER_URL || req.protocol + '://' + req.get('host');
     fs.readdirSync(uploadOptions.uploadDir).forEach( name => {
         var stats = fs.statSync(uploadOptions.uploadDir + '/' + name);
         if (stats.isFile() && uploadOptions.fileTypes.includes(mime.lookup(name))) {
@@ -85,7 +85,7 @@ const uploadHandler = multer({
 
 app.use('/upload/', uploadHandler.array('files[]', 20), function(req, res) {
     var files = [];
-    var uploadHost = req.protocol + '://' + req.get('host');
+    var uploadHost = process.env.SERVER_URL || req.protocol + '://' + req.get('host');
     req.files.forEach( f => {
         files.push({
             name: f.filename,


### PR DESCRIPTION
With `SERVER_URL` as environment variable it's possible now to change the image urls to "hardcoded" url. If not available, old method is used.

Currently this is important, if you're using a proxy between, because otherwise req.protocol is always http -> public image urls has http-scheme instead of https.